### PR TITLE
Update the `gradle-build-configuration` field

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -56,5 +56,7 @@ jobs:
           use-gradlew: true
           gradle-build-module: |-
             :
+          # `compileClasspath` configuration has no dependencies in multiplatform
+          # projects.
           gradle-build-configuration: |-
-            compileClasspath
+            jvmCompileClasspath


### PR DESCRIPTION
`compileClasspath` configuration has no dependencies in multiplatform projects.