### PR TITLE
Publishing packages for macosArm64

### DIFF
--- a/.github/workflows/publish-macosArm64.yml
+++ b/.github/workflows/publish-macosArm64.yml
@@ -1,0 +1,64 @@
+name: 'Publish macosArm64'
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dorg.gradle.welcome=never
+  GPG_SEC: ${{ secrets.PGP_SEC }}
+  GPG_PASSWORD: ${{ secrets.PGP_PASSWORD }}
+
+jobs:
+  publish:
+    name: 'Publish macosArm64'
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch Git tags, so that semantic version can be calculated.
+          # Alternatively, run `git fetch --prune --unshallow --tags` as the
+          # next step, see
+          # https://github.com/actions/checkout/issues/206#issuecomment-607496604.
+          fetch-depth: 0
+
+      - name: 'Set up Java 17'
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+          java-package: jdk+fx
+
+      - name: 'Cache ~/.konan'
+        id: cache-konan
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}-release
+          restore-keys: |
+            ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}-
+            ${{ runner.os }}-konan-
+
+      - name: 'Run unit tests'
+        id: test
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: |
+            macosArm64Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Publish a release (macosArm64 target)'
+        id: publish-linux
+        uses: gradle/gradle-build-action@v2
+        with:
+            gradle-version: wrapper
+            arguments: |
+              build
+              publishMacosArm64PublicationToGitHubRepository
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-macosArm64.yml
+++ b/.github/workflows/publish-macosArm64.yml
@@ -53,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Publish a release (macosArm64 target)'
-        id: publish-linux
+        id: publish-macosArm64
         uses: gradle/gradle-build-action@v2
         with:
             gradle-version: wrapper

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
             mingwX64(),
             linuxX64(),
             macosX64(),
+            macosArm64(),
         ).forEach { target ->
             getByName("${target.name}Main").dependsOn(nativeMain)
             getByName("${target.name}Test").dependsOn(nativeTest)


### PR DESCRIPTION
### What's done:
 * Added `macosArm64` target 
 * Added `publish-macosArm64.yml` workflow file that uses self-hosted runner based on `macosArm64` hardware