### PR TITLE
okio-extras for macosArm64 follow-ups

### DIFF
--- a/.github/workflows/publish-macosArm64.yml
+++ b/.github/workflows/publish-macosArm64.yml
@@ -23,25 +23,7 @@ jobs:
           # next step, see
           # https://github.com/actions/checkout/issues/206#issuecomment-607496604.
           fetch-depth: 0
-
-      - name: 'Set up Java 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: zulu
-          java-package: jdk+fx
-
-      - name: 'Cache ~/.konan'
-        id: cache-konan
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}-release
-          restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}-
-            ${{ runner.os }}-konan-
-
+      # Assumption that Java 17 is already present on self-hosted runner
       - name: 'Run unit tests'
         id: test
         uses: gradle/gradle-build-action@v2
@@ -58,7 +40,6 @@ jobs:
         with:
             gradle-version: wrapper
             arguments: |
-              build
               publishMacosArm64PublicationToGitHubRepository
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What's done:
 * Cleaned `publish-macosArm64.yml` action in order to make it faster and do no extra tasks